### PR TITLE
fix: Project Path was incorrect on WSL

### DIFF
--- a/clone
+++ b/clone
@@ -29,6 +29,12 @@ elif [[ "$OSTYPE" == "msys" ]]; then
     PROJECTS_FILE="/c/Users/$USERNAME/AppData/Roaming/Code/User/globalStorage/alefragnani.project-manager/projects.json"
 elif [[ $(grep -i microsoft /proc/version) ]]; then
     PROJECTS_FILE="/mnt/c/Users/$USER/AppData/Roaming/Code/User/globalStorage/alefragnani.project-manager/projects.json"
+    # This condition is for when the `Project Manager` extension is installed on Windows and not on WSL.
+    if [ ! -d "$PROJECTS_FILE" ]; then
+        WINDOWS_USERNAME=$(cmd.exe /c echo %USERNAME% 2>/dev/null | tr -d '\r')
+        PROJECTS_FILE="/mnt/c/Users/$WINDOWS_USERNAME/AppData/Roaming/Code/User/globalStorage/alefragnani.project-manager/projects.json"
+    fi
+
     path_prefix='vscode-remote://wsl+ubuntu'
 else
     PROJECTS_FILE="$HOME/.config/Code/User/globalStorage/alefragnani.project-manager/projects.json"


### PR DESCRIPTION
It seems that on Windows when using WSL, the `Project Manager` extension is installed on Windows. This causes the project path to not target the correct user.

I added a "if" case when the WSL user path does not exist to use the Windows user path instead.